### PR TITLE
Add `standalone` attribute to XML declaration

### DIFF
--- a/OSPSuite.Dimensions.xml
+++ b/OSPSuite.Dimensions.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 
 <DimensionFactory>
   <Dimensions>


### PR DESCRIPTION
@Yuri05 AFAIK, the XML document doesn't rely on any external stylesheets or DTDs, so this attribute can be used.